### PR TITLE
GOLD-155 fix: incorrect BN parsing causing wrong stake readings

### DIFF
--- a/src/class/StatsFunctions.ts
+++ b/src/class/StatsFunctions.ts
@@ -211,7 +211,9 @@ export const recordCoinStats = async (latestCycle: number, lastStoredCycle: numb
               'readableReceipt' in current.wrappedEVMAccount &&
               current.wrappedEVMAccount.readableReceipt?.stakeInfo?.stake
             ) {
-              const stakeAmountBN = new BN(current.wrappedEVMAccount.readableReceipt.stakeInfo.stake.toString())
+              const stakeAmountBN = new BN(
+                current.wrappedEVMAccount.readableReceipt.stakeInfo.stake.toString()
+              ) // changed to accomodate BigInt instead of Hex string
               return sum.add(stakeAmountBN)
             } else {
               return sum
@@ -223,7 +225,9 @@ export const recordCoinStats = async (latestCycle: number, lastStoredCycle: numb
               'readableReceipt' in current.wrappedEVMAccount &&
               current.wrappedEVMAccount.readableReceipt?.stakeInfo?.stake
             ) {
-              const unStakeAmountBN = new BN(current.wrappedEVMAccount.readableReceipt.stakeInfo.stake.toString())
+              const unStakeAmountBN = new BN(
+                current.wrappedEVMAccount.readableReceipt.stakeInfo.stake.toString()
+              )
               return sum.add(unStakeAmountBN)
             } else {
               return sum


### PR DESCRIPTION
![image](https://github.com/shardeum/explorer-server/assets/24825299/a6571a90-b078-4625-9592-c59e19226c57)

More info in the ticket. cc @abdulazeem-tk4vr 