### PR TITLE
RED-243: update validator node documentation link in Header component

### DIFF
--- a/src/frontend/components/Header/Header.tsx
+++ b/src/frontend/components/Header/Header.tsx
@@ -31,7 +31,7 @@ export const Header: React.FC<Record<string, never>> = () => {
             label=""
             options={[
               { key: 'https://shardeum.org/betanet', value: 'Shardeum Betanet' },
-              { key: 'https://docs.shardeum.org/node/run/validator', value: 'Run a validator node' },
+              { key: 'https://docs.shardeum.org/docs/node/run/validator', value: 'Run a validator node' },
             ]}
           />
         )


### PR DESCRIPTION
https://linear.app/shm/issue/RED-243/run-a-validator-node-page-from-explorer-wont-load

![image](https://github.com/user-attachments/assets/26368ee1-5f9d-4c11-8452-2f68a307effb)

Summary: update from `https://docs.shardeum.org/node/run/validator` to `https://docs.shardeum.org/docs/node/run/validator`