### PR TITLE
Fix/update receipt structure before states

### DIFF
--- a/src/storage/receipt.ts
+++ b/src/storage/receipt.ts
@@ -82,7 +82,7 @@ export async function processReceiptData(receipts: Receipt[], saveOnlyNewData = 
     }
     let modifiedReceiptObj = {
       ...receiptObj,
-      beforeStateAccounts: config.storeReceiptBeforeStates ? receiptObj.beforeStateAccounts : [],
+      beforeStates: config.storeReceiptBeforeStates ? receiptObj.beforeStates : [],
     }
     if (saveOnlyNewData) {
       const receiptExist = await queryReceiptByReceiptId(tx.txId)


### PR DESCRIPTION
Linear: https://linear.app/shm/issue/GOLD-270/
Summary: Rename beforeStateAccounts to beforeStates in line with new receipt structure