### PR TITLE
chore: fix function name downloadCyclcesBetweenCycles

### DIFF
--- a/scripts/data_patcher.ts
+++ b/scripts/data_patcher.ts
@@ -35,7 +35,7 @@ const start = async (): Promise<void> => {
   await DataSync.downloadAndSyncGenesisAccounts() // To sync accounts data that are from genesis accounts/accounts data that the network start with
 
   console.log('startCycle', startCycle, 'totalCyclesToSync', totalCyclesToSync)
-  await DataSync.downloadCyclcesBetweenCycles(startCycle, totalCyclesToSync, patchOnlyMissingData)
+  await DataSync.downloadCyclesBetweenCycles(startCycle, totalCyclesToSync, patchOnlyMissingData)
   console.log('Cycles Patched!')
   await DataSync.downloadReceiptsBetweenCycles(startCycle, totalCyclesToSync, patchOnlyMissingData)
   console.log('Receipts Patched!')


### PR DESCRIPTION
Spotted a typo in `downloadCyclcesBetweenCycles`—"Cyclces" was misspelled.
Fixed it to `downloadCyclesBetweenCycles` so the function name is correct and consistent.
Nothing else was changed.