### PR TITLE
fix: fix incorrect API URL format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,9 +16,9 @@
         "@fastify/nextjs": "10.0.1",
         "@fastify/rate-limit": "8.0.3",
         "@fastify/websocket": "8.2.0",
-        "@shardeum-foundation/lib-archiver-discovery": "1.2.0-prerelease.0",
-        "@shardeum-foundation/lib-crypto-utils": "4.2.0-prerelease.0",
-        "@shardeum-foundation/lib-types": "1.3.0-prerelease.0",
+        "@shardeum-foundation/lib-archiver-discovery": "1.3.0-prerelease.0",
+        "@shardeum-foundation/lib-crypto-utils": "4.3.0-prerelease.0",
+        "@shardeum-foundation/lib-types": "1.4.0-prerelease.0",
         "@svgr/webpack": "8.0.1",
         "@types/node": "18.19.1",
         "@types/react": "18.0.25",
@@ -3981,11 +3981,11 @@
       }
     },
     "node_modules/@shardeum-foundation/lib-archiver-discovery": {
-      "version": "1.2.0-prerelease.0",
-      "resolved": "https://registry.npmjs.org/@shardeum-foundation/lib-archiver-discovery/-/lib-archiver-discovery-1.2.0-prerelease.0.tgz",
-      "integrity": "sha512-O4picAV8rYay2MvtXTFRvk7pqlTFPi/l8t0dluBwBJTusftiQ0QzkbnhIKjp4VnU8aR2WqHlByKLFVhsy6m0rw==",
+      "version": "1.3.0-prerelease.0",
+      "resolved": "https://registry.npmjs.org/@shardeum-foundation/lib-archiver-discovery/-/lib-archiver-discovery-1.3.0-prerelease.0.tgz",
+      "integrity": "sha512-SzexKcEgHje76eXOSY52hYOLx+ZljtCWrzkvpaXCJCXVGkZ5da8sQBhxE0AY0QocDoUBhX90LFqoSc0jqIaF5g==",
       "dependencies": {
-        "@shardeum-foundation/lib-crypto-utils": "4.2.0-prerelease.0",
+        "@shardeum-foundation/lib-crypto-utils": "4.3.0-prerelease.0",
         "axios": "1.6.1",
         "gts": "3.1.1"
       }
@@ -4001,11 +4001,11 @@
       }
     },
     "node_modules/@shardeum-foundation/lib-crypto-utils": {
-      "version": "4.2.0-prerelease.0",
-      "resolved": "https://registry.npmjs.org/@shardeum-foundation/lib-crypto-utils/-/lib-crypto-utils-4.2.0-prerelease.0.tgz",
-      "integrity": "sha512-3uu/VVmFJjUlvhA9p7cjBYBNKVu6R0zl3c7xduFrLZpA/lSBMHYgNPG0GSDafK1QCYAYaZVbQ2eX8Kb7qJEcgQ==",
+      "version": "4.3.0-prerelease.0",
+      "resolved": "https://registry.npmjs.org/@shardeum-foundation/lib-crypto-utils/-/lib-crypto-utils-4.3.0-prerelease.0.tgz",
+      "integrity": "sha512-2h8nB6vyZ9LL7tBlXuZj/anFhQszGK3jIhD7bw18GN+TYupRBma4H1E/Qt6G7L5UXysnWoPQcDs1otfkKxZaow==",
       "dependencies": {
-        "@shardeum-foundation/lib-types": "1.3.0-prerelease.0",
+        "@shardeum-foundation/lib-types": "1.4.0-prerelease.0",
         "buffer-xor": "2.0.2",
         "fast-stable-stringify": "1.0.0",
         "sodium-native": "4.3.1"
@@ -4015,9 +4015,9 @@
       }
     },
     "node_modules/@shardeum-foundation/lib-types": {
-      "version": "1.3.0-prerelease.0",
-      "resolved": "https://registry.npmjs.org/@shardeum-foundation/lib-types/-/lib-types-1.3.0-prerelease.0.tgz",
-      "integrity": "sha512-tIudohI5u5ldcwHdeg2/IMYbtCPCv0/SMQv3NUQCo6cUsn0swXYRiI2q0ClVrPnkDAzALSYbUZrENP76SQT9Yw=="
+      "version": "1.4.0-prerelease.0",
+      "resolved": "https://registry.npmjs.org/@shardeum-foundation/lib-types/-/lib-types-1.4.0-prerelease.0.tgz",
+      "integrity": "sha512-6x8iT6Fyi/s2RRr/O4KI6082KRaPNT1+KDT7C1sAaws+njCpM4r9iypeBpbMB9jb8Xo1/6sh6iVuex2gWx4LMQ=="
     },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shardeum-foundation/explorer",
-  "version": "1.1.0-prerelease.0",
+  "version": "1.2.0-prerelease.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@shardeum-foundation/explorer",
-      "version": "1.1.0-prerelease.0",
+      "version": "1.2.0-prerelease.0",
       "dependencies": {
         "@ethereumjs/rlp": "5.0.0",
         "@ethereumjs/tx": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shardeum-foundation/explorer",
-  "version": "1.1.0-prerelease.0",
+  "version": "1.2.0-prerelease.0",
   "main": "dist/server.js",
   "scripts": {
     "server": "npm run prepare && node dist/server.js",

--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
     "release:major": "npm run prepare && npm run build && npm version major && git push --follow-tags"
   },
   "dependencies": {
-    "@shardeum-foundation/lib-archiver-discovery": "1.2.0-prerelease.0",
-    "@shardeum-foundation/lib-crypto-utils": "4.2.0-prerelease.0",
-    "@shardeum-foundation/lib-types": "1.3.0-prerelease.0",
+    "@shardeum-foundation/lib-archiver-discovery": "1.3.0-prerelease.0",
+    "@shardeum-foundation/lib-crypto-utils": "4.3.0-prerelease.0",
+    "@shardeum-foundation/lib-types": "1.4.0-prerelease.0",
     "@ethereumjs/rlp": "5.0.0",
     "@ethereumjs/tx": "5.0.0",
     "@ethereumjs/util": "9.0.0",

--- a/scripts/data_sync_checker.ts
+++ b/scripts/data_sync_checker.ts
@@ -6,7 +6,7 @@ import { isDeepStrictEqual } from 'util'
 import { writeFileSync } from 'fs'
 crypto.init(config.hashKey)
 
-const API_SERVER_URL = 'http:/127.0.0.1:6001'
+const API_SERVER_URL = 'http://127.0.0.1:6001'
 
 const startCycle = 0
 const endCycle = 0


### PR DESCRIPTION
Spotted a typo in `API_SERVER_URL`. The URL was missing a second slash after `http:`, which could cause issues with requests.  

Changed:  
```js
const API_SERVER_URL = 'http:/127.0.0.1:6001'
```  
To:  
```js
const API_SERVER_URL = 'http://127.0.0.1:6001'
```  

Now the API requests should work as expected.