### PR TITLE
SHARD-2245: remove betanet labels

### DIFF
--- a/src/frontend/components/Header/Header.tsx
+++ b/src/frontend/components/Header/Header.tsx
@@ -23,14 +23,14 @@ export const Header: React.FC<Record<string, never>> = () => {
   const navLinks = [
     { key: '/', value: 'Home' },
     {
-      key: 'betanet',
-      value: 'About Betanet',
+      key: 'mainnet',
+      value: 'About Mainnet',
       render: () => {
         return (
           <TopBarDropdown
             label=""
             options={[
-              { key: 'https://shardeum.org/betanet', value: 'Shardeum Betanet' },
+              { key: 'https://shardeum.org/', value: 'Shardeum Mainnet' },
               { key: 'https://docs.shardeum.org/docs/node/run/validator', value: 'Run a validator node' },
             ]}
           />

--- a/src/frontend/dashboard/SearchBox/SearchBox.tsx
+++ b/src/frontend/dashboard/SearchBox/SearchBox.tsx
@@ -18,7 +18,7 @@ export const SearchBox: React.FC<SearchBoxProps> = ({ mode }) => {
   return (
     <div className={styles.SearchBox}>
       <div className={styles.titleWrapper}>
-        <h4 className={styles.title}>The Shardeum Betanet Explorer</h4>
+        <h4 className={styles.title}>The Shardeum Explorer</h4>
         <NetworkMode mode={mode as Modes} />
       </div>
       <div className={styles.box}>


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Replaced 'Betanet' references with 'Mainnet' in navigation.

- Updated explorer title to remove 'Betanet'.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Header.tsx</strong><dd><code>Update navigation to reference Mainnet instead of Betanet</code></dd></summary>
<hr>

src/frontend/components/Header/Header.tsx

<li>Changed navigation label from 'About Betanet' to 'About Mainnet'.<br> <li> Updated dropdown link from 'Shardeum Betanet' to 'Shardeum Mainnet'.


</details>


  </td>
  <td><a href="https://github.com/shardeum/explorer/pull/68/files#diff-3baf3ab440dea8d68784bb0a88a2ee799a29753c79c5482c76b94ec05c1e1571">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SearchBox.tsx</strong><dd><code>Remove 'Betanet' from explorer title</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/dashboard/SearchBox/SearchBox.tsx

<li>Changed explorer title from 'The Shardeum Betanet Explorer' to 'The <br>Shardeum Explorer'.


</details>


  </td>
  <td><a href="https://github.com/shardeum/explorer/pull/68/files#diff-0a9d5da8a4ae38f088d65a9c3cec1c636bb565d305f4d5809e25c6cf6a18e9db">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>