### PR TITLE
fix: footer year to reflect current year

### DIFF
--- a/src/frontend/components/Footer/Footer.tsx
+++ b/src/frontend/components/Footer/Footer.tsx
@@ -55,7 +55,7 @@ export const Footer: React.FC = () => {
       <hr />
       <div className={styles.social}>
         <div>
-          <span>Shardeum</span> © 2023
+          <span>Shardeum</span> © {new Date().getFullYear()}
         </div>
         <div className={styles.wrapper}>
           {socials.map((social, index) => (


### PR DESCRIPTION
### **User description**
![image](https://github.com/user-attachments/assets/0e90acc4-703b-4fe2-b1cf-ca4f0befa404)


___

### **PR Type**
Bug fix


___

### **Description**
- Update footer to display the current year dynamically

- Replace hardcoded year with JavaScript Date function


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Footer.tsx</strong><dd><code>Make footer year dynamic using JavaScript Date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/components/Footer/Footer.tsx

<li>Replaced hardcoded year (2023) with dynamic current year<br> <li> Used JavaScript's Date object to fetch the year


</details>


  </td>
  <td><a href="https://github.com/shardeum/explorer/pull/74/files#diff-d7ae2d991dc4b77d4633fc0e097e5b339a496be42a6033e4880179e12d667ebb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>