### PR TITLE
SHARD-2407: skip aggregating secure transfer amount spent for total supply calculation

### DIFF
--- a/src/class/StatsFunctions.ts
+++ b/src/class/StatsFunctions.ts
@@ -5,7 +5,7 @@ import * as NodeStats from '../stats/nodeStats'
 import * as Metadata from '../stats/metadata'
 import * as Cycle from '../storage/cycle'
 import * as Transaction from '../storage/transaction'
-import { InternalTXType, TransactionSearchType, TransactionType } from '../types'
+import { InternalTXType, TransactionSearchType, TransactionType, WrappedDataReceipt } from '../types'
 import BN from 'bn.js'
 import BigNumber from 'decimal.js'
 import { CycleRecord } from '@shardeum-foundation/lib-types/build/src/p2p/CycleCreatorTypes'
@@ -378,7 +378,16 @@ export const recordCoinStats = async (latestCycle: number, lastStoredCycle: numb
           }, new BN(0))
           // Calculate total gas burnt in cycle
           const gasBurnt = transactions.reduce((sum, current) => {
-            if ('amountSpent' in current.wrappedEVMAccount && current.wrappedEVMAccount.amountSpent) {
+            const isInternalTx = current.transactionType === TransactionType.InternalTxReceipt
+            const internalTxType = isInternalTx
+              ? (current.wrappedEVMAccount as WrappedDataReceipt)?.readableReceipt?.internalTx?.internalTXType
+              : undefined
+            // ignore amountSpent for InternalTxType.TransferFromSecureAccount because it is not a gas fee but actually the value
+            if (
+              'amountSpent' in current.wrappedEVMAccount &&
+              current.wrappedEVMAccount.amountSpent &&
+              internalTxType !== InternalTXType.TransferFromSecureAccount
+            ) {
               // remove prefix 0x from amountSpent hex string
               const amountSpentBN = new BN(current.wrappedEVMAccount.amountSpent.substring(2), 16)
               return sum.add(amountSpentBN)


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Exclude `amountSpent` from secure account transfers in gas calculation

- Add check for `InternalTxType.TransferFromSecureAccount` in transaction loop

- Prevent double counting value as gas fee in total supply stats

- Minor import update for `WrappedDataReceipt` type


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>StatsFunctions.ts</strong><dd><code>Exclude secure account transfer value from gas burnt stats</code></dd></summary>
<hr>

src/class/StatsFunctions.ts

<li>Updated gas burnt calculation to skip <code>amountSpent</code> for secure account <br>transfers.<br> <li> Added logic to detect <code>InternalTxType.TransferFromSecureAccount</code> and <br>exclude it.<br> <li> Imported <code>WrappedDataReceipt</code> type for type checking.


</details>


  </td>
  <td><a href="https://github.com/shardeum/explorer/pull/76/files#diff-f4bb4caa7a382e29d5b6ad08bad5f1c73556ca2cdd6eacbbf46c18e91daecd1d">+11/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>