### PR TITLE
SHARD-2424: hide network state hash for cycle (for now)

### DIFF
--- a/src/frontend/cycle/CycleDetail/CycleDetail.tsx
+++ b/src/frontend/cycle/CycleDetail/CycleDetail.tsx
@@ -43,10 +43,10 @@ export const CycleDetail: React.FC = () => {
               <div className={styles.value}>{data?.cycleRecord?.networkId}</div>
             </div>
 
-            <div className={styles.item}>
-              <div className={styles.title}>Network State Hash</div>
-              <div className={styles.value}>{data?.cycleRecord?.networkStateHash || '-'}</div>
-            </div>
+            {/*<div className={styles.item}>*/}
+            {/*  <div className={styles.title}>Network State Hash</div>*/}
+            {/*  <div className={styles.value}>{data?.cycleRecord?.networkStateHash || '-'}</div>*/}
+            {/*</div>*/}
 
             <div className={styles.item}>
               <div className={styles.title}>Cycle Number</div>


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Temporarily hides the Network State Hash field in cycle details

- Comments out related JSX code for future re-enabling

- No changes to backend logic or data fetching

- UI remains clean without displaying unused data


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CycleDetail.tsx</strong><dd><code>Temporarily hide Network State Hash in cycle details</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/cycle/CycleDetail/CycleDetail.tsx

<li>Commented out the Network State Hash display section<br> <li> Ensured the field is hidden from the UI for now<br> <li> Added comments for easy future re-enabling


</details>


  </td>
  <td><a href="https://github.com/shardeum/explorer/pull/82/files#diff-325286c7ea316c585d5b405d29e04ead833b2b5a7b0277ae42ec7881a2b3a2ba">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>