### PR TITLE
account for burned supply in circulating supply stats

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -36,6 +36,7 @@ export const config = {
   apiUrl: '',
   verbose: false,
   genesisSHMSupply: 249000000,
+  burnedSupply: 500000, // 500,000 SHM burned
   dbPath: process.env.DB_PATH?.replace(/\/+$/, '') || '.', // remove
   rateLimit: 100,
   GTM_Id: '',

--- a/src/stats/supplyStats.ts
+++ b/src/stats/supplyStats.ts
@@ -221,7 +221,7 @@ export async function updateSupplyStatsCache(): Promise<void> {
     
     const secureAccountsBalance = await calculateSecureAccountsBalance()
     
-    const circulatingSupply = BASE_SUPPLY - totalShmBurned + totalShmRewarded - secureAccountsBalance
+    const circulatingSupply = BASE_SUPPLY - totalShmBurned + totalShmRewarded - secureAccountsBalance - config.burnedSupply
     
     await saveSupplyStatsCache({
       lastCycle: latestCycle,


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Deducts burned supply from circulating supply calculation

- Adds `burnedSupply` parameter to configuration


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Add burnedSupply parameter to configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/index.ts

<li>Introduced new <code>burnedSupply</code> parameter in config<br> <li> Set default burned supply to 500,000 SHM


</details>


  </td>
  <td><a href="https://github.com/shardeum/explorer/pull/91/files#diff-198a1431d7c5e26ea78bc6e54b34b54e6f8ab342dd48ea11013877e8466a87c5">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>supplyStats.ts</strong><dd><code>Subtract burned supply in circulating supply calculation</code>&nbsp; </dd></summary>
<hr>

src/stats/supplyStats.ts

<li>Updated circulating supply formula to subtract burned supply<br> <li> Now deducts <code>config.burnedSupply</code> from circulating supply


</details>


  </td>
  <td><a href="https://github.com/shardeum/explorer/pull/91/files#diff-5f33646dc136d46ab282d7c183e79eb8b3cb561f12c8f8249fb69ba352775770">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>