### PR TITLE
SHARD-2738: value display fix for erc20

### DIFF
--- a/src/frontend/utils/calculateValue.ts
+++ b/src/frontend/utils/calculateValue.ts
@@ -28,7 +28,9 @@ export const calculateTokenValue = (
 ): string => {
   try {
     if (txType === TokenType.ERC_20 || txType === TokenType.EVM_Internal) {
-      const decimalsValue = tokenTx.contractInfo.decimals ? parseInt(tokenTx.contractInfo.decimals) : 18
+      const decimalsValue = tokenTx.contractInfo.decimals && !isNaN(parseInt(tokenTx.contractInfo.decimals)) 
+        ? parseInt(tokenTx.contractInfo.decimals) 
+        : 18
 
       return tokenTx.tokenValue === '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
         ? 'unlimited'

--- a/src/frontend/utils/calculateValue.ts
+++ b/src/frontend/utils/calculateValue.ts
@@ -1,5 +1,5 @@
 import web3 from 'web3'
-import { utils } from 'ethers'
+import { formatUnits } from 'ethers'
 import { TokenTx, TokenType, TransactionType } from '../../types'
 import BN from 'bn.js'
 import { fromWeiNoTrailingComma } from './fromWeiNoTrailingComma'
@@ -46,7 +46,7 @@ export const calculateTokenValue = (
       }
       
       console.log('calculateTokenValue - attempting formatUnits with:', tokenTx.tokenValue, decimalsValue)
-      const formatted = utils.formatUnits(tokenTx.tokenValue, decimalsValue)
+      const formatted = formatUnits(tokenTx.tokenValue, decimalsValue)
       console.log('calculateTokenValue - formatUnits result:', formatted)
       
       return fullValue ? formatted : roundTokenValue(formatted)

--- a/src/frontend/utils/calculateValue.ts
+++ b/src/frontend/utils/calculateValue.ts
@@ -27,25 +27,40 @@ export const calculateTokenValue = (
   fullValue = true
 ): string => {
   try {
+    console.log('calculateTokenValue - Input:', { tokenTx, txType, tokenId, fullValue })
+    
     if (txType === TokenType.ERC_20 || txType === TokenType.EVM_Internal) {
+      console.log('calculateTokenValue - ERC20/EVM_Internal branch')
+      console.log('calculateTokenValue - contractInfo:', tokenTx.contractInfo)
+      console.log('calculateTokenValue - tokenValue:', tokenTx.tokenValue)
+      
       const decimalsValue = tokenTx.contractInfo.decimals && !isNaN(parseInt(tokenTx.contractInfo.decimals)) 
         ? parseInt(tokenTx.contractInfo.decimals) 
         : 18
+      
+      console.log('calculateTokenValue - decimalsValue:', decimalsValue)
 
-      return tokenTx.tokenValue === '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
-        ? 'unlimited'
-        : fullValue
-        ? utils.formatUnits(tokenTx.tokenValue, decimalsValue)
-        : roundTokenValue(utils.formatUnits(tokenTx.tokenValue, decimalsValue))
+      if (tokenTx.tokenValue === '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff') {
+        console.log('calculateTokenValue - unlimited value detected')
+        return 'unlimited'
+      }
+      
+      console.log('calculateTokenValue - attempting formatUnits with:', tokenTx.tokenValue, decimalsValue)
+      const formatted = utils.formatUnits(tokenTx.tokenValue, decimalsValue)
+      console.log('calculateTokenValue - formatUnits result:', formatted)
+      
+      return fullValue ? formatted : roundTokenValue(formatted)
 
       // : round(web3.utils.fromWei(tokenTx.tokenValue, "ether"));
     } else if (txType === TokenType.ERC_721) {
+      console.log('calculateTokenValue - ERC721 branch')
       return tokenTx.tokenEvent === 'Approval For All'
         ? tokenTx.tokenValue === '0x0000000000000000000000000000000000000000000000000000000000000001'
           ? 'True'
           : 'False'
         : shortTokenValue(web3.utils.hexToNumberString(tokenTx.tokenValue))
     } else if (txType === TokenType.ERC_1155) {
+      console.log('calculateTokenValue - ERC1155 branch')
       return tokenTx.tokenEvent === 'Approval For All'
         ? tokenTx.tokenValue === '0x0000000000000000000000000000000000000000000000000000000000000001'
           ? 'True'
@@ -56,7 +71,11 @@ export const calculateTokenValue = (
         ? shortTokenValue(web3.utils.hexToNumberString(tokenTx.tokenValue.substring(0, 66)))
         : shortTokenValue(web3.utils.hexToNumberString('0x' + tokenTx.tokenValue.substring(66, 130)))
     }
+    
+    console.log('calculateTokenValue - No matching token type, txType:', txType)
   } catch (e) {
+    console.error('calculateTokenValue - Error caught:', e)
+    console.error('calculateTokenValue - Error stack:', e.stack)
     return 'error in calculating tokenValue'
   }
   return 'error in calculating tokenValue'

--- a/src/frontend/utils/calculateValue.ts
+++ b/src/frontend/utils/calculateValue.ts
@@ -27,40 +27,25 @@ export const calculateTokenValue = (
   fullValue = true
 ): string => {
   try {
-    console.log('calculateTokenValue - Input:', { tokenTx, txType, tokenId, fullValue })
-    
     if (txType === TokenType.ERC_20 || txType === TokenType.EVM_Internal) {
-      console.log('calculateTokenValue - ERC20/EVM_Internal branch')
-      console.log('calculateTokenValue - contractInfo:', tokenTx.contractInfo)
-      console.log('calculateTokenValue - tokenValue:', tokenTx.tokenValue)
-      
       const decimalsValue = tokenTx.contractInfo.decimals && !isNaN(parseInt(tokenTx.contractInfo.decimals)) 
         ? parseInt(tokenTx.contractInfo.decimals) 
         : 18
-      
-      console.log('calculateTokenValue - decimalsValue:', decimalsValue)
 
-      if (tokenTx.tokenValue === '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff') {
-        console.log('calculateTokenValue - unlimited value detected')
-        return 'unlimited'
-      }
-      
-      console.log('calculateTokenValue - attempting formatUnits with:', tokenTx.tokenValue, decimalsValue)
-      const formatted = formatUnits(tokenTx.tokenValue, decimalsValue)
-      console.log('calculateTokenValue - formatUnits result:', formatted)
-      
-      return fullValue ? formatted : roundTokenValue(formatted)
+      return tokenTx.tokenValue === '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
+        ? 'unlimited'
+        : fullValue
+        ? formatUnits(tokenTx.tokenValue, decimalsValue)
+        : roundTokenValue(formatUnits(tokenTx.tokenValue, decimalsValue))
 
       // : round(web3.utils.fromWei(tokenTx.tokenValue, "ether"));
     } else if (txType === TokenType.ERC_721) {
-      console.log('calculateTokenValue - ERC721 branch')
       return tokenTx.tokenEvent === 'Approval For All'
         ? tokenTx.tokenValue === '0x0000000000000000000000000000000000000000000000000000000000000001'
           ? 'True'
           : 'False'
         : shortTokenValue(web3.utils.hexToNumberString(tokenTx.tokenValue))
     } else if (txType === TokenType.ERC_1155) {
-      console.log('calculateTokenValue - ERC1155 branch')
       return tokenTx.tokenEvent === 'Approval For All'
         ? tokenTx.tokenValue === '0x0000000000000000000000000000000000000000000000000000000000000001'
           ? 'True'
@@ -71,11 +56,7 @@ export const calculateTokenValue = (
         ? shortTokenValue(web3.utils.hexToNumberString(tokenTx.tokenValue.substring(0, 66)))
         : shortTokenValue(web3.utils.hexToNumberString('0x' + tokenTx.tokenValue.substring(66, 130)))
     }
-    
-    console.log('calculateTokenValue - No matching token type, txType:', txType)
   } catch (e) {
-    console.error('calculateTokenValue - Error caught:', e)
-    console.error('calculateTokenValue - Error stack:', e.stack)
     return 'error in calculating tokenValue'
   }
   return 'error in calculating tokenValue'


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed ERC20 value display for transactions with invalid decimals.

- Replaced deprecated `utils.formatUnits` with `formatUnits` from ethers.

- Improved handling of decimals parsing for ERC20 tokens.

- Ensured correct value formatting for ERC20 and EVM_Internal tokens.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>calculateValue.ts</strong><dd><code>Fix and enhance ERC20 value formatting logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/utils/calculateValue.ts

<li>Replaced <code>utils.formatUnits</code> with <code>formatUnits</code> from ethers.<br> <li> Improved decimals parsing with additional validation.<br> <li> Enhanced value formatting logic for ERC20/EVM_Internal tokens.<br> <li> Ensured fallback to 18 decimals if parsing fails.


</details>


  </td>
  <td><a href="https://github.com/shardeum/explorer/pull/92/files#diff-5472b7cf4251004cdeeb2febc19cbdf608eeaf5c5d9291e4ec3d218192dfb6c4">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>